### PR TITLE
add deep merge option for $ref

### DIFF
--- a/bin/swagger-merger.js
+++ b/bin/swagger-merger.js
@@ -13,13 +13,14 @@ let noArgs = true
 
 program
   .version(require('../package.json').version)
-  .usage('[-h] [-v] [-c] [-o file] <-i file | file>')
+  .usage('[-h] [-v] [-c] [-m] [-o file] <-i file | file>')
   .description('Merge multiple swagger files into a swagger file, just support JSON/YAML.')
   .option('-i, --input <*.json|yaml|yml file>', 'input a main/entry JSON/YAML swagger file, MANDATORY',
     /^.+\.(json|yaml|yml)$/gi, null)
   .option('-o, --output <*.json|yaml|yml file>', 'output a merged JSON/YAML swagger file, default is `swagger.*`',
     /^.+\.(json|yaml|yml)$/gi, null)
   .option('-c, --compact', 'compact JSON/YAML format string', null, null)
+  .option('-m, --deep-merge', 'enable deep-merge on resolving $ref', null, false)
   .option('--debug', 'debug mode, such as print error tracks', null, null)
   .action((options) => {
     noArgs = !(options.input)
@@ -30,7 +31,8 @@ program
     merger({
       input: options.input || '',
       output: options.output || '',
-      compact: options.compact
+      compact: options.compact,
+      deepMerge: options.deepMerge
     }).catch(e => {
       if (options.debug) {
         console.error(e)

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const fmtconv = require('fmtconv')
 
 const { isHTTP, isTmpDir, download } = require('./remote')
-const { splitReference, parseRef, sliceHashtag } = require('./reference')
+const { parseRef, sliceHashtag } = require('./reference')
 
 const regFixBlock = new RegExp(`{\\[(.+?)\\]}`, 'g')
 
@@ -23,7 +23,7 @@ const regFixBlock = new RegExp(`{\\[(.+?)\\]}`, 'g')
  * @api public
  */
 function mergeJSON (tag, dir, obj) {
-  const json = mergeNestedJSON(tag, dir, obj, obj)
+  const json = mergeNestedJSON(tag, dir, obj)
   return JSON.stringify(json).replace(regFixBlock, s => {
     return s.substring(1, s.length - 1)
   })
@@ -60,9 +60,11 @@ function mergeNestedJSON (tag, dir, obj) {
       continue
     }
 
-    // read the url contents.
-    if (isHTTP(ref)) {
-      let { filePath, hashtag } = splitReference(ref)
+    // parse ref
+    let { protocol, filePath, hashtag } = parseRef(ref)
+
+    // read the url contents
+    if (isHTTP(protocol)) {
       ret[key] = download(tag, filePath) + (hashtag ? ('#' + hashtag) : '')
       continue
     }
@@ -71,17 +73,14 @@ function mergeNestedJSON (tag, dir, obj) {
       dir = ''
     }
 
-    // parse out the file path and hashtag path.
-    let { filePath, hashtag } = parseRef(ref)
-
-    let childObj
-    let childFileObj
+    // skip if ref to the root file
     if (!filePath) {
       ret[key] = ref
       continue
     }
 
     filePath = path.join(dir, filePath)
+
     // read the file contents.
     try {
       fs.accessSync(filePath, fs.R_OK)
@@ -95,20 +94,19 @@ function mergeNestedJSON (tag, dir, obj) {
       continue
     }
 
+    let childObj
     // core code - swagger merge $ref
     let ext = path.extname(filePath).toLowerCase()
     if (!ext) ext = '.yaml'
     switch (ext) {
       case '.json':
         // handle the hashtag
-        childFileObj = JSON.parse(fileContext)
-        childObj = sliceHashtag(childFileObj, hashtag)
+        childObj = sliceHashtag(JSON.parse(fileContext), hashtag)
         break
       case '.yaml':
       case '.yml':
         // yaml to json, handle the hashtag
-        childFileObj = JSON.parse(fmtconv.stringYAML2JSON(fileContext))
-        childObj = sliceHashtag(childFileObj, hashtag)
+        childObj = sliceHashtag(JSON.parse(fmtconv.stringYAML2JSON(fileContext)), hashtag)
         break
       default:
         continue

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const fmtconv = require('fmtconv')
 
 const { isHTTP, isTmpDir, download, undo } = require('./remote')
-const { splitReference, sliceHashtag } = require('./reference')
+const { splitReference, parseRef, sliceHashtag } = require('./reference')
 
 const regFixBlock = new RegExp(`{\\[(.+?)\\]}`, 'g')
 
@@ -23,9 +23,10 @@ const regFixBlock = new RegExp(`{\\[(.+?)\\]}`, 'g')
  * @api public
  */
 function mergeJSON (tag, dir, obj) {
-  return JSON.parse(mergeNestedJSON(tag, dir, JSON.stringify(obj)).replace(regFixBlock, s => {
+  const json = mergeNestedJSON(tag, dir, obj, obj)
+  return JSON.stringify(json).replace(regFixBlock, s => {
     return s.substring(1, s.length - 1)
-  }))
+  })
 }
 
 /**
@@ -33,149 +34,99 @@ function mergeJSON (tag, dir, obj) {
  *
  * @param {string} tag
  * @param {string} dir
- * @param {string} doc
- * @return {string}
+ * @param {object} obj
+ * @return {object}
  * @api private
  */
-function mergeNestedJSON (tag, dir, doc) {
-  // merge $ref
-  doc = mergeJSONByRef(tag, dir, doc)
+function mergeNestedJSON (tag, dir, obj) {
+  if (!obj) {
+    return obj
+  }
+  let ret
+  switch (obj.constructor.name) {
+    case 'Object':
+      ret = {}
+      break
+    case 'Array':
+      ret = []
+      break
+    default:
+      return obj
+  }
 
-  // merge $ref#*
-  doc = mergeJSONByRefHashtag(tag, dir, doc)
-
-  return doc
-}
-
-const regRef = new RegExp(`([ \n\r]*)("\\$ref")( *):( *)"[^"{}]+"([ \n\r]*)`, 'gm')
-const regBlock = new RegExp(`(^{)|(}[ \n\r]*$)`, 'g')
-
-function removeJSONBlock (s) {
-  return s.replace(regBlock, '')
-}
-
-/**
- * Merge JSON swagger $ref signs.
- *
- * @param {string} tag
- * @param {string} dir
- * @param {string} doc
- * @return {string}
- * @api private
- */
-function mergeJSONByRef (tag, dir, doc) {
-  return doc.replace(regRef, s => {
-    let ref = JSON.parse('{' + s + '}').$ref
+  for (const [key, ref] of Object.entries(obj)) {
+    if (!key.startsWith('$ref')) {
+      ret[key] = mergeNestedJSON(tag, dir, ref)
+      continue
+    }
 
     // read the url contents.
     if (isHTTP(ref)) {
       let { filePath, hashtag } = splitReference(ref)
-      return '"$ref":"' + download(tag, filePath) + (hashtag ? ('#' + hashtag) : '') + '"'
-    } else if (isTmpDir(ref)) {
+      ret[key] = download(tag, filePath) + (hashtag ? ('#' + hashtag) : '')
+      continue
+    }
+
+    if (isTmpDir(ref)) {
       dir = ''
-      s = '"$ref":"' + undo(ref) + '"'
     }
 
     // parse out the file path and hashtag path.
-    let { filePath, hashtag } = splitReference(path.join(dir, ref))
+    let { filePath, hashtag } = parseRef(ref)
 
+    let childObj
+    let childFileObj
+    if (!filePath) {
+      ret[key] = ref
+      continue
+    }
+
+    filePath = path.join(dir, filePath)
     // read the file contents.
-    let dirName = path.dirname(filePath)
     try {
       fs.accessSync(filePath, fs.R_OK)
     } catch (e) {
-      return s
+      console.error('error: "' + ref + '" does not exist.')
+      continue
     }
     let fileContext = '' + fs.readFileSync(filePath)
     if (!fileContext) {
       if (!isTmpDir(ref)) console.error('error: "' + ref + '" should not be empty.')
-      return s
+      continue
     }
 
     // core code - swagger merge $ref
     let ext = path.extname(filePath).toLowerCase()
     if (!ext) ext = '.yaml'
-    do {
-      switch (ext) {
-        case '.json':
-          // handle the hashtag
-          fileContext = sliceHashtag(fileContext, hashtag)
-          return mergeNestedJSON(tag, dirName, removeJSONBlock(fileContext))
-        case '.yaml':
-        case '.yml':
-          // yaml to json, handle the hashtag
-          fileContext = sliceHashtag(fmtconv.stringYAML2JSON(fileContext), hashtag)
-          return mergeNestedJSON(tag, dirName, removeJSONBlock(fileContext))
-        default:
-          ext = null
-      }
-    } while (ext)
-    return s
-  })
-}
-
-const regRefHashtag = new RegExp(`("\\$ref#[A-Za-z0-9_#-]+")( *):( *)"[^"{}]+"`, 'gm')
-const regRefHashtagSign = new RegExp(`\\$ref#[A-Za-z0-9_#-]+`, 'gm')
-
-/**
- * Merge JSON swagger $ref#* signs.
- *
- * @param {string} tag
- * @param {string} dir
- * @param {string} doc
- * @return {string}
- * @api private
- */
-function mergeJSONByRefHashtag (tag, dir, doc) {
-  return doc.replace(regRefHashtag, s => {
-    let refSign = s.match(regRefHashtagSign)[0]
-    let ref = JSON.parse('{' + s + '}')[refSign]
-
-    // read the url contents.
-    if (isHTTP(ref)) {
-      let { filePath, hashtag } = splitReference(ref)
-      return '"' + refSign + '":"' + download(tag, filePath) + (hashtag ? ('#' + hashtag) : '') + '"'
-    } else if (isTmpDir(ref)) {
-      dir = ''
-      s = '"' + refSign + '":"' + undo(ref) + '"'
+    switch (ext) {
+      case '.json':
+        // handle the hashtag
+        childFileObj = JSON.parse(fileContext)
+        childObj = sliceHashtag(childFileObj, hashtag)
+        break
+      case '.yaml':
+      case '.yml':
+        // yaml to json, handle the hashtag
+        childFileObj = JSON.parse(fmtconv.stringYAML2JSON(fileContext))
+        childObj = sliceHashtag(childFileObj, hashtag)
+        break
+      default:
+        continue
     }
 
-    // parse out the file path and hashtag path.
-    let { filePath, hashtag } = splitReference(path.join(dir, ref))
-
-    // read the file contents.
     let dirName = path.dirname(filePath)
-    try {
-      fs.accessSync(filePath, fs.R_OK)
-    } catch (e) {
-      return s
-    }
-    let fileContext = '' + fs.readFileSync(filePath)
-    if (!fileContext) {
-      if (!isTmpDir(ref)) console.error('error: "' + ref + '" should not be empty.')
-      return s
-    }
+    childObj = mergeNestedJSON(tag, dirName, childObj)
 
-    let ext = path.extname(filePath).toLowerCase()
-    if (!ext) ext = '.yaml'
-    do {
-      // core code - swagger merge $ref#*
-      switch (ext) {
-        case '.json':
-          // handle the hashtag
-          fileContext = sliceHashtag(fileContext, hashtag)
-          return mergeNestedJSON(tag, dirName, removeJSONBlock(fileContext))
-        case '.yaml':
-        case '.yml':
-          // yaml to json, handle the hashtag
-          fileContext = sliceHashtag(fmtconv.stringYAML2JSON(fileContext), hashtag)
-          return mergeNestedJSON(tag, dirName, removeJSONBlock(fileContext))
-        default:
-          ext = null
-      }
-    } while (ext)
-    return s
-  })
+    if (ret.constructor.name === 'Object' && Object.keys(ret).length === 0 && childObj.constructor.name === 'Array') {
+      ret = []
+    }
+    if (childObj.constructor.name === 'Array') {
+      ret = ret.concat(childObj)
+    } else {
+      ret = Object.assign({}, ret, childObj)
+    }
+  }
+  return ret
 }
 
 module.exports = mergeJSON

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -7,6 +7,7 @@ const path = require('path')
 const fs = require('fs')
 
 const fmtconv = require('fmtconv')
+const deepmerge = require('deepmerge')
 
 const { isHTTP, isTmpDir, download } = require('./remote')
 const { parseRef, sliceHashtag } = require('./reference')
@@ -19,11 +20,12 @@ const regFixBlock = new RegExp(`{\\[(.+?)\\]}`, 'g')
  * @param {string} tag
  * @param {string} dir
  * @param {object} obj
+ * @param {boolean} isDeepMerge
  * @return {string}
  * @api public
  */
-function mergeJSON (tag, dir, obj) {
-  const json = mergeNestedJSON(tag, dir, obj)
+function mergeJSON (tag, dir, obj, isDeepMerge) {
+  const json = mergeNestedJSON(tag, dir, obj, isDeepMerge)
   return JSON.stringify(json).replace(regFixBlock, s => {
     return s.substring(1, s.length - 1)
   })
@@ -35,10 +37,11 @@ function mergeJSON (tag, dir, obj) {
  * @param {string} tag
  * @param {string} dir
  * @param {object} obj
+ * @param {boolean} isDeepMerge
  * @return {object}
  * @api private
  */
-function mergeNestedJSON (tag, dir, obj) {
+function mergeNestedJSON (tag, dir, obj, isDeepMerge) {
   // same return type as the input object
   let ret
   if (isObject(obj)) {
@@ -53,7 +56,7 @@ function mergeNestedJSON (tag, dir, obj) {
   for (const [key, ref] of Object.entries(obj)) {
     // merge child object
     if (!key.startsWith('$ref')) {
-      ret[key] = mergeNestedJSON(tag, dir, ref)
+      ret[key] = mergeNestedJSON(tag, dir, ref, isDeepMerge)
       continue
     }
 
@@ -109,18 +112,26 @@ function mergeNestedJSON (tag, dir, obj) {
 
     let refObj = sliceHashtag(parsedContent, hashtag)
     let dirName = path.dirname(filePath)
-    refObj = mergeNestedJSON(tag, dirName, refObj)
+    refObj = mergeNestedJSON(tag, dirName, refObj, isDeepMerge)
 
     if (isEmptyObject(ret) && isArray(refObj)) {
       ret = []
     }
-    if (isArray(refObj)) {
-      ret = ret.concat(refObj)
-    } else {
-      ret = Object.assign({}, ret, refObj)
-    }
+    ret = mergeObjects(ret, refObj, isDeepMerge)
   }
   return ret
+}
+
+function mergeObjects (obj1, obj2, isDeepMerge) {
+  if (isDeepMerge) {
+    return deepmerge(obj1, obj2)
+  } else {
+    if (isArray(obj1)) {
+      return obj1.concat(obj2)
+    } else {
+      return Object.assign({}, obj1, obj2)
+    }
+  }
 }
 
 function isEmptyObject (obj) {

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -39,22 +39,19 @@ function mergeJSON (tag, dir, obj) {
  * @api private
  */
 function mergeNestedJSON (tag, dir, obj) {
-  if (!obj) {
-    return obj
-  }
+  // same return type as the input object
   let ret
-  switch (obj.constructor.name) {
-    case 'Object':
-      ret = {}
-      break
-    case 'Array':
-      ret = []
-      break
-    default:
-      return obj
+  if (isObject(obj)) {
+    ret = {}
+  } else if (isArray(obj)) {
+    ret = []
+  } else {
+    // base case
+    return obj
   }
 
   for (const [key, ref] of Object.entries(obj)) {
+    // merge child object
     if (!key.startsWith('$ref')) {
       ret[key] = mergeNestedJSON(tag, dir, ref)
       continue
@@ -63,23 +60,21 @@ function mergeNestedJSON (tag, dir, obj) {
     // parse ref
     let { protocol, filePath, hashtag } = parseRef(ref)
 
-    // read the url contents
+    // URL ref
     if (isHTTP(protocol)) {
+      // temporary file path for saving remote file
       ret[key] = download(tag, filePath) + (hashtag ? ('#' + hashtag) : '')
       continue
     }
-
-    if (isTmpDir(ref)) {
-      dir = ''
-    }
-
-    // skip if ref to the root file
+    // local ref
     if (!filePath) {
       ret[key] = ref
       continue
     }
-
-    filePath = path.join(dir, filePath)
+    // remote ref, handling relative path
+    if (!path.isAbsolute(filePath)) {
+      filePath = path.join(dir, filePath)
+    }
 
     // read the file contents.
     try {
@@ -88,43 +83,56 @@ function mergeNestedJSON (tag, dir, obj) {
       console.error('error: "' + ref + '" does not exist.')
       continue
     }
-    let fileContext = '' + fs.readFileSync(filePath)
-    if (!fileContext) {
+    let fileContent = '' + fs.readFileSync(filePath)
+    if (!fileContent) {
       if (!isTmpDir(ref)) console.error('error: "' + ref + '" should not be empty.')
       continue
     }
 
-    let childObj
-    // core code - swagger merge $ref
+    let parsedContent
     let ext = path.extname(filePath).toLowerCase()
     if (!ext) ext = '.yaml'
     switch (ext) {
       case '.json':
         // handle the hashtag
-        childObj = sliceHashtag(JSON.parse(fileContext), hashtag)
+        parsedContent = JSON.parse(fileContent)
         break
       case '.yaml':
       case '.yml':
         // yaml to json, handle the hashtag
-        childObj = sliceHashtag(JSON.parse(fmtconv.stringYAML2JSON(fileContext)), hashtag)
+        parsedContent = JSON.parse(fmtconv.stringYAML2JSON(fileContent))
         break
       default:
+        // nothing to do
         continue
     }
 
+    let refObj = sliceHashtag(parsedContent, hashtag)
     let dirName = path.dirname(filePath)
-    childObj = mergeNestedJSON(tag, dirName, childObj)
+    refObj = mergeNestedJSON(tag, dirName, refObj)
 
-    if (ret.constructor.name === 'Object' && Object.keys(ret).length === 0 && childObj.constructor.name === 'Array') {
+    if (isEmptyObject(ret) && isArray(refObj)) {
       ret = []
     }
-    if (childObj.constructor.name === 'Array') {
-      ret = ret.concat(childObj)
+    if (isArray(refObj)) {
+      ret = ret.concat(refObj)
     } else {
-      ret = Object.assign({}, ret, childObj)
+      ret = Object.assign({}, ret, refObj)
     }
   }
   return ret
+}
+
+function isEmptyObject (obj) {
+  return isObject(obj) && Object.keys(obj).length === 0
+}
+
+function isObject (obj) {
+  return obj && obj.constructor.name === 'Object'
+}
+
+function isArray (obj) {
+  return obj && obj.constructor.name === 'Array'
 }
 
 module.exports = mergeJSON

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -56,7 +56,12 @@ function mergeNestedJSON (tag, dir, obj, isDeepMerge) {
   for (const [key, ref] of Object.entries(obj)) {
     // merge child object
     if (!key.startsWith('$ref')) {
-      ret[key] = mergeNestedJSON(tag, dir, ref, isDeepMerge)
+      const child = mergeNestedJSON(tag, dir, ref, isDeepMerge)
+      if (isObject(ret[key]) && isObject(child)) {
+        ret[key] = mergeObjects(ret[key], child, isDeepMerge)
+      } else {
+        ret[key] = child
+      }
       continue
     }
 
@@ -112,11 +117,13 @@ function mergeNestedJSON (tag, dir, obj, isDeepMerge) {
 
     let refObj = sliceHashtag(parsedContent, hashtag)
     let dirName = path.dirname(filePath)
+    // ref object merged its children
     refObj = mergeNestedJSON(tag, dirName, refObj, isDeepMerge)
-
+    // initialize ret as empty array if the first $ref is array
     if (isEmptyObject(ret) && isArray(refObj)) {
       ret = []
     }
+    // merge ref object
     ret = mergeObjects(ret, refObj, isDeepMerge)
   }
   return ret

--- a/lib/merge_json.js
+++ b/lib/merge_json.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 
 const fmtconv = require('fmtconv')
 
-const { isHTTP, isTmpDir, download, undo } = require('./remote')
+const { isHTTP, isTmpDir, download } = require('./remote')
 const { splitReference, parseRef, sliceHashtag } = require('./reference')
 
 const regFixBlock = new RegExp(`{\\[(.+?)\\]}`, 'g')

--- a/lib/merger_json.js
+++ b/lib/merger_json.js
@@ -23,7 +23,7 @@ function mergerJSON (param) {
   }
 
   // merge to JSON
-  let obj = mergeJSON(param.tag, param.dir, JSON.parse(doc))
+  let obj = mergeJSON(param.tag, param.dir, JSON.parse(doc), param.deepMerge)
 
   let dump
   if (param.output) {

--- a/lib/merger_yaml.js
+++ b/lib/merger_yaml.js
@@ -24,7 +24,7 @@ function mergerYAML (param) {
   }
 
   // merge to JSON
-  let obj = mergeJSON(param.tag, param.dir, JSON.parse(doc))
+  let obj = mergeJSON(param.tag, param.dir, JSON.parse(doc), param.deepMerge)
 
   let dump
   if (param.output) {

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -11,6 +11,8 @@
  * @return {object}
  * @api private
  */
+const url = require('url')
+
 function splitReference (ref) {
   // parse out the file path.
   // file path cases: ./responses.yaml
@@ -38,6 +40,19 @@ function splitReference (ref) {
   return { filePath, hashtag }
 }
 
+function parseRef (ref) {
+  const u = url.parse(ref)
+  const filePath = u.path
+  let hashtag = null
+  if (u.hash) {
+    const mo = u.hash.match(/#\/?(.+)/)
+    if (mo) {
+      hashtag = mo[1]
+    }
+  }
+  return { filePath, hashtag }
+}
+
 /**
  * Slice hashtag path from JSON content.
  *
@@ -46,17 +61,16 @@ function splitReference (ref) {
  * @return {string}
  * @api private
  */
-function sliceHashtagJSON (content, hashtag) {
+function sliceHashtagJSON (obj, hashtag) {
   if (hashtag) {
-    let obj = JSON.parse(content)
     hashtag.split('/').every(k => {
       obj = Object.getOwnPropertyDescriptor(obj, k).value
       return obj
     })
-    content = JSON.stringify(obj)
   }
-  return content
+  return obj
 }
 
 module.exports.splitReference = splitReference
 module.exports.sliceHashtag = sliceHashtagJSON
+module.exports.parseRef = parseRef

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -13,36 +13,10 @@
  */
 const url = require('url')
 
-function splitReference (ref) {
-  // parse out the file path.
-  // file path cases: ./responses.yaml
-  // parse out the hashtag path from the file path.
-  // hashtag path cases: #/components/root/get
-  let filePath, hashtag
-  let idxHashtag = ref.indexOf('#')
-  if (idxHashtag > 5) {
-    filePath = ref.slice(0, idxHashtag)
-    if (filePath.endsWith('/') || filePath.endsWith('\\')) {
-      filePath = ref
-      return { filePath }
-    }
-
-    hashtag = ref.slice(idxHashtag + 1)
-
-    // in case of windows operating system
-    hashtag = hashtag.replace(/\\/g, '/')
-
-    if (hashtag.startsWith('/')) {
-      hashtag = hashtag.slice(1)
-    }
-  }
-  if (!filePath) filePath = ref
-  return { filePath, hashtag }
-}
-
 function parseRef (ref) {
   const u = url.parse(ref)
-  const filePath = u.path
+  const protocol = u.protocol
+  const filePath = (protocol ? protocol + '//' : '') + (u.host || '') + (u.path || '')
   let hashtag = null
   if (u.hash) {
     const mo = u.hash.match(/#\/?(.+)/)
@@ -50,13 +24,13 @@ function parseRef (ref) {
       hashtag = mo[1]
     }
   }
-  return { filePath, hashtag }
+  return { protocol, filePath, hashtag }
 }
 
 /**
  * Slice hashtag path from JSON content.
  *
- * @param {string} content
+ * @param {object} obj
  * @param {string} hashtag
  * @return {string}
  * @api private
@@ -71,6 +45,5 @@ function sliceHashtagJSON (obj, hashtag) {
   return obj
 }
 
-module.exports.splitReference = splitReference
 module.exports.sliceHashtag = sliceHashtagJSON
 module.exports.parseRef = parseRef

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -137,15 +137,8 @@ function clean (tag) {
   deleteFolder(path.join(tmpDir, tag))
 }
 
-function undo (ref) {
-  let { filePath, hashtag } = splitReference(ref)
-  return tmpPaths[filePath] ? (tmpPaths[filePath] +
-    (hashtag ? '#' + hashtag : '')) : ref
-}
-
 module.exports.isHTTP = isHTTP
 module.exports.isTmpDir = isTmpDir
 module.exports.download = download
 module.exports.downloading = downloading
 module.exports.clean = clean
-module.exports.undo = undo

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -12,14 +12,12 @@ const crypto = require('crypto')
 
 const async = require('async')
 
-const { splitReference } = require('./reference')
-
 let tmpDir = path.join(os.tmpdir(), 'swagger-merger')
 let tmpPaths = {}
 let tasks = {}
 
 function isHTTP (p) {
-  return p.startsWith('http://') || p.startsWith('https://')
+  return p === 'http:' || p === 'https:'
 }
 
 function isTmpDir (p) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "async": "^2.6.1",
     "co": "^4.6.0",
     "commander": "^2.19.0",
+    "deepmerge": "^4.2.2",
     "fmtconv": "^1.0.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,6 +1461,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-require-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"


### PR DESCRIPTION
I'm using this tool for a while, and multi $ref feature is very helpful for separating a single large OpenAPI document.
But there are no way to merge objects when refs have the same keys, which is especially useful on reusing schemas. For example:

- UserId.yml
```
name: userId
schema:
  type: string
```

- and in path definition:
```
get:
  parameters:
    - $ref: ./components/parameters/UserId.yml
      in: path
      required: true

...

post:
  parameters:
    - $ref: ./components/parameters/UserId.yml
      in: query
```

Currently, ref resolution is done by replacing `$ref` string by the file content, which makes difficult to merge objects because JSON.parse() does not handle duplicate keys (later wins). So I tried to make change to treat JSON as object, and then replace or merge $ref key recursively.

I am using this fork in my several projects and seems to be working for now.
If interested, I will write some tests later.

Thanks